### PR TITLE
Event subscriptions - UI updates when the state changes

### DIFF
--- a/app/src/main/java/io/homeassistant/android/api/HassUtils.java
+++ b/app/src/main/java/io/homeassistant/android/api/HassUtils.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import io.homeassistant.android.api.results.Entity;
+import io.homeassistant.android.api.results.EventData;
 
 import static io.homeassistant.android.api.Domain.AUTOMATION;
 import static io.homeassistant.android.api.Domain.BINARY_SENSOR;
@@ -50,6 +51,21 @@ public final class HassUtils {
                 Entity entity = Ason.deserialize((Ason) o, Entity.class);
                 entityMap.put(entity.id, entity);
             }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Extract an updated entity from an event and update the entityMap with the new state
+     *
+     * @param result    the EventData to extract from
+     * @param entityMap the Map where entities are store with their id as key
+     * @return true if items were updated, else false
+     */
+    public static boolean updateEntityFromEventResult(@Nullable EventData result, @NonNull Map<String, Entity> entityMap) {
+        if (result != null) {
+            entityMap.put(result.entity_id, result.new_state);
             return true;
         }
         return false;

--- a/app/src/main/java/io/homeassistant/android/api/requests/SubscribeEventsRequest.java
+++ b/app/src/main/java/io/homeassistant/android/api/requests/SubscribeEventsRequest.java
@@ -1,0 +1,13 @@
+package io.homeassistant.android.api.requests;
+
+import com.afollestad.ason.Ason;
+
+public class SubscribeEventsRequest extends Ason {
+
+    protected final String type = "subscribe_events";
+    protected String event_type = null;
+
+    public SubscribeEventsRequest(String eventType) {
+        this.event_type = eventType;
+    }
+}

--- a/app/src/main/java/io/homeassistant/android/api/results/Event.java
+++ b/app/src/main/java/io/homeassistant/android/api/results/Event.java
@@ -1,0 +1,11 @@
+package io.homeassistant.android.api.results;
+
+public class Event {
+
+    public int id;
+    public String event_type;
+    public String origin;
+    public String time_fired;
+    public EventData data;
+
+}

--- a/app/src/main/java/io/homeassistant/android/api/results/EventData.java
+++ b/app/src/main/java/io/homeassistant/android/api/results/EventData.java
@@ -1,0 +1,8 @@
+package io.homeassistant.android.api.results;
+
+public class EventData {
+
+    public String entity_id;
+    public Entity new_state;
+    public Entity old_state;
+}

--- a/app/src/main/java/io/homeassistant/android/api/results/EventResult.java
+++ b/app/src/main/java/io/homeassistant/android/api/results/EventResult.java
@@ -1,0 +1,10 @@
+package io.homeassistant.android.api.results;
+
+import com.afollestad.ason.Ason;
+
+public class EventResult {
+    public int id;
+    public String type;
+    public Event event;
+
+}


### PR DESCRIPTION
This is an initial commit to automatically update the UI when an item changes state.  No need to pull and refresh anymore for state updates.  

@Maxr1998 CommunicationHandler / ServiceCommunicator probably needs another message/method here to refresh a specific entity. Right now, I'm calling the updateStates() which is not ideal since it does everything. ViewAdapter will also need to have logic added to find that entity and update its state.
